### PR TITLE
EET Compatibility

### DIFF
--- a/sod2bg2_iu/sod2bg2_iu.tp2
+++ b/sod2bg2_iu/sod2bg2_iu.tp2
@@ -26,6 +26,7 @@ PRINT @9001
 
 INCLUDE ~sod2bg2_iu/lib/functions.tpa~		//adding functions
 
+ACTION_IF NOT GAME_IS ~EET~ THEN BEGIN
 
 ///////////////////////
 // Adding Projectiles//
@@ -836,7 +837,7 @@ COPY ~sod2bg2_iu/itm/sourcecap2/dtksrcp2.itm~ ~override~
   SAY UNIDENTIFIED_DESC @2221
   SAY DESC @2232
 
-
+END //This is the end for EET not importing already existing items
 
 
 


### PR DESCRIPTION
All SoD items already exist in the EET game. However, the mod's other features to add them to creatures or upgrade them by Cespenar/Cromwell would be a welcome addition to EET.

The proposal is to check for EET and skip the item importation part of your mod. The remaining parts work without change.

This is to avoid unique items to appear twice in the EET game or even install inconsistencies.