### PR TITLE
bug: REPLACE_TEXTUALLY in binary file

### DIFF
--- a/sod2bg2_iu/sod2bg2_iu.tp2
+++ b/sod2bg2_iu/sod2bg2_iu.tp2
@@ -5551,8 +5551,13 @@ COMPILE ~sod2bg2_iu/dialogue/roger1.d~		//Belt of the Cunning Rogue
 COMPILE ~sod2bg2_iu/dialogue/scsain1.d~		//Shield of Egons +2
 COMPILE ~sod2bg2_iu/dialogue/trskin04a.d~		//Bracers of Perseverance
 COMPILE ~sod2bg2_iu/dialogue/mourner6a.d~		//Flute of the Immaculate Breeze
-COPY_EXISTING ~demson.dlg~ ~override~		
-	REPLACE_TEXTUALLY ~plat15~ ~dtkrnd04~	//Mail of the Hallowed Hero +3/Pride of the Legion +2
+
+COPY_EXISTING ~demson.dlg~ ~override~
+	DECOMPILE_AND_PATCH
+	BEGIN
+		REPLACE_TEXTUALLY ~plat15~ ~dtkrnd04~	//Mail of the Hallowed Hero +3/Pride of the Legion +2
+	END
+
 COMPILE ~sod2bg2_iu/dialogue/ohdazoth.d~		//Vexed Armor
 COMPILE ~sod2bg2_iu/dialogue/tokcre01.d~		//Boots of Speed/Boots of the Fox
 


### PR DESCRIPTION
(copied from G3 forum)
sod2bg2_iu seems to break the demson.dlg file. Mods that I install after sod2bg2_iu that also try to modify this file all fail ("can't verify the action").

If  understand correctly; this mod does this:

```
COPY_EXISTING ~demson.dlg~ ~override~		
	REPLACE_TEXTUALLY ~plat15~ ~dtkrnd04~	//Mail of the Hallowed Hero +3/Pride of the Legion +2
```

 

This might work in all other files which are ".d", but this one is a ".dlg" which if I'm not wrong is a binary file.

And as you just replace 6 bytes with 8 bytes, this might not work totally as expected.

When I inspect the resource with NearInfinity, before install sod2bg2_ui, I see
```

SetGlobal("PaladinPlot","GLOBAL",60)
GiveItemCreate("dtkrnd04",Player1,0,0,0)
GiveItemCreate("shld30",Player1,0,0,0)
ActionOverride(Player1,RegainPaladinHood())
```

After installing, I see

![Screenshot_20210604_191039 png 51b75197c1d66e43a77d503cc446763f](https://user-images.githubusercontent.com/444063/120888127-ffd97480-c5f6-11eb-9992-3f5bf46c18cc.png)

Notice the two unclosed parenthesis(es?) and the red error image.

You can take everything I wrote with a grain of salt, I know next to nothing about IE resources or weidu.

My change was tested on a bare (unmodded) bg2 2.6.6 installation on linux, that's all. NearInfinity shows the actions 59 and 60 in demson.dlg to be correctly modified.

According to the weidu doc (or rather, what I understand of it), the preferred way to do this would be to create a .d file with an ALTER_TRANS. but that's above my current ability.